### PR TITLE
Fixes build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 before_script:
-	- npm install -g grunt grunt-cli
+    - npm install -g grunt-cli
 
 language: node_js
 node_js:
-  	- "0.10"
-	- "0.12"
-	- "4.0.0"
-  	- "iojs-v2.3.4"
-  	- "iojs-v3.0.0"
-  	- "iojs-v3.3.1"
+    - "0.10"
+    - "0.12"
+    - "4.0.0"
+    - "iojs-v2.3.4"
+    - "iojs-v3.0.0"
+    - "iojs-v3.3.1"


### PR DESCRIPTION
Travis CI did not initialize build process, due to error ```syntax error: (<unknown>): found character that cannot start any token while scanning for the next token at line``` found while linting .yml file.

Probably using tab characters to indent your YAML file does not work.